### PR TITLE
RepositoryBase: Improve DynamoDB client init

### DIFF
--- a/packages/utils/src/repository.ts
+++ b/packages/utils/src/repository.ts
@@ -8,6 +8,8 @@ export class RepositoryBase {
 
     protected clientConfig?: DynamoDB.DynamoDBClientConfig
 
+    private db: DynamoDB.DynamoDB | undefined
+
     constructor(
         protected readonly table: {
             envKeyName: string
@@ -33,12 +35,14 @@ export class RepositoryBase {
      * That's because the resource access given to each lambda also sets he environment variables needed.
      */
     protected getDb() {
+        if (this.db) return this.db
         if (!this.tableName || this.tableName.length < 3) //AWS rule
             throw new Error(`Could not find env var: ${this.table.envKeyName}`)
         if (this.clientConfig?.region) { // WTF https://github.com/aws/aws-sdk-js-v3/issues/3469#issuecomment-1078404172
             process.env['AWS_REGION'] = this.clientConfig.region.toString()
         }
-        return new DynamoDB.DynamoDB(this.clientConfig ?? {})
+        this.db = new DynamoDB.DynamoDB(this.clientConfig ?? {})
+        return this.db
     }
 
     protected async scan<T>(args?: {


### PR DESCRIPTION
Initializes a private variable `db` to store the DynamoDB instance and modifies the `getDb()` method to return the stored instance if it exists.